### PR TITLE
Add argparse CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,4 @@ dependencies = []
 Homepage = "https://example.com"
 
 [project.scripts]
-rom-library-organizer = "rom_library_organizer.__main__:main"
+rom-library-organizer = "rom_library_organizer.cli:main"

--- a/src/rom_library_organizer/__main__.py
+++ b/src/rom_library_organizer/__main__.py
@@ -1,7 +1,6 @@
-"""Command-line interface for rom_library_organizer."""
+"""Command-line entry point for rom_library_organizer."""
 
-def main():
-    print("ROM Library Organizer CLI placeholder")
+from .cli import main
 
 if __name__ == "__main__":
     main()

--- a/src/rom_library_organizer/cli.py
+++ b/src/rom_library_organizer/cli.py
@@ -1,0 +1,33 @@
+"""Command-line interface for rom_library_organizer."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Parse command-line arguments and execute the organizer."""
+    parser = argparse.ArgumentParser(
+        description="Organize a ROM library for selected platforms"
+    )
+    parser.add_argument(
+        "target_directory",
+        help="Directory containing the ROM files to organize",
+    )
+    parser.add_argument(
+        "platforms",
+        nargs="*",
+        help="Names of the platforms to process",
+    )
+    args = parser.parse_args(argv)
+
+    print(f"Target directory: {args.target_directory}")
+    if args.platforms:
+        print(f"Selected platforms: {', '.join(args.platforms)}")
+    else:
+        print("No platforms selected.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI module parsing target directory and platforms
- expose new CLI via project scripts for easy invocation
- route `python -m rom_library_organizer` through the new CLI

## Testing
- `PYTHONPATH=src python -m rom_library_organizer.cli --help`
- `PYTHONPATH=src python -m rom_library_organizer --help`


------
https://chatgpt.com/codex/tasks/task_b_68c3fc9c64cc83269aca3fb7489ef21b