### PR TITLE
Add ROM scanner utility

### DIFF
--- a/src/rom_library_organizer/scanner.py
+++ b/src/rom_library_organizer/scanner.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Utilities for scanning directories for ROM files.
+
+The :func:`scan_roms` generator walks a directory tree and yields
+information about each ROM file that it finds. Files with unrecognised
+extensions are ignored.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generator
+
+# Common ROM file extensions. This list is intentionally conservative and can
+# be expanded in the future as new formats are supported.
+ROM_EXTENSIONS: set[str] = {
+    ".nes",
+    ".sfc",
+    ".smc",
+    ".gba",
+    ".gb",
+    ".gbc",
+    ".n64",
+    ".z64",
+    ".v64",
+    ".nds",
+    ".iso",
+    ".bin",
+}
+
+
+@dataclass
+class RomInfo:
+    """Metadata about a ROM file discovered during scanning."""
+
+    path: Path
+    extension: str
+    size: int
+    name: str
+
+
+def scan_roms(root_path: str | Path) -> Generator[RomInfo, None, None]:
+    """Yield information for ROM files under ``root_path``.
+
+    Parameters
+    ----------
+    root_path:
+        Directory to search for ROM files. Subdirectories are traversed
+        recursively.
+
+    Yields
+    ------
+    RomInfo
+        Metadata for each recognised ROM file. Files with extensions not in
+        :data:`ROM_EXTENSIONS` are skipped silently.
+    """
+
+    root = Path(root_path)
+    if not root.exists():
+        return
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        ext = path.suffix.lower()
+        if ext not in ROM_EXTENSIONS:
+            continue
+        stat = path.stat()
+        yield RomInfo(path=path, extension=ext, size=stat.st_size, name=path.name)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from rom_library_organizer.scanner import scan_roms
+
+
+def test_scan_roms_filters_and_reports(tmp_path: Path) -> None:
+    rom = tmp_path / "game.nes"
+    rom.write_bytes(b"abc")
+    ignored = tmp_path / "notes.txt"
+    ignored.write_text("not a rom")
+
+    results = list(scan_roms(tmp_path))
+    assert len(results) == 1
+    info = results[0]
+    assert info.path == rom
+    assert info.extension == ".nes"
+    assert info.size == 3
+    assert info.name == "game.nes"
+    # ensure unknown file is not included
+    assert all(res.path != ignored for res in results)


### PR DESCRIPTION
## Summary
- implement `scan_roms` to walk directories and collect ROM metadata
- support common ROM extensions and skip unknown files
- add tests for scanner behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c3ff523a4483269ae5e97adb599b8b