### PR TITLE
Add platform base class and dynamic CLI loading

### DIFF
--- a/src/rom_library_organizer/cli.py
+++ b/src/rom_library_organizer/cli.py
@@ -3,13 +3,30 @@
 from __future__ import annotations
 
 import argparse
-from typing import Sequence
+from importlib import import_module
+from typing import Sequence, Type
+
+from .platforms import PlatformOrganizer
+
+
+def load_platform_class(name: str) -> Type[PlatformOrganizer]:
+    """Dynamically import a platform organizer class by name."""
+    module_name = f"rom_library_organizer.platforms.{name}"
+    module = import_module(module_name)
+    for obj in module.__dict__.values():
+        if (
+            isinstance(obj, type)
+            and issubclass(obj, PlatformOrganizer)
+            and obj is not PlatformOrganizer
+        ):
+            return obj
+    raise ValueError(f"No PlatformOrganizer subclass found in {module_name}")
 
 
 def main(argv: Sequence[str] | None = None) -> None:
     """Parse command-line arguments and execute the organizer."""
     parser = argparse.ArgumentParser(
-        description="Organize a ROM library for selected platforms"
+        description="Organize a ROM library for selected platforms",
     )
     parser.add_argument(
         "target_directory",
@@ -23,9 +40,17 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     print(f"Target directory: {args.target_directory}")
-    if args.platforms:
-        print(f"Selected platforms: {', '.join(args.platforms)}")
-    else:
+    organizers: list[PlatformOrganizer] = []
+    for name in args.platforms:
+        try:
+            cls = load_platform_class(name)
+            organizers.append(cls())
+            print(f"Loaded platform organizer: {name}")
+        except ModuleNotFoundError:
+            print(f"Unknown platform: {name}")
+        except ValueError as exc:
+            print(str(exc))
+    if not organizers:
         print("No platforms selected.")
 
 

--- a/src/rom_library_organizer/platforms/__init__.py
+++ b/src/rom_library_organizer/platforms/__init__.py
@@ -1,0 +1,5 @@
+"""Platform-specific organizers."""
+
+from .base import PlatformOrganizer
+
+__all__ = ["PlatformOrganizer"]

--- a/src/rom_library_organizer/platforms/base.py
+++ b/src/rom_library_organizer/platforms/base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class PlatformOrganizer(ABC):
+    """Abstract base class for platform-specific ROM organization."""
+
+    @classmethod
+    @abstractmethod
+    def is_supported(cls, file: Path) -> bool:
+        """Return ``True`` if the given file is handled by this platform."""
+
+    @abstractmethod
+    def rename(self, file_metadata: Mapping[str, Any]) -> str:
+        """Return the new filename for ``file_metadata``."""


### PR DESCRIPTION
## Summary
- Define abstract `PlatformOrganizer` in new `platforms` package
- Enhance CLI to dynamically import platform organizers based on user input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4408d2ad48326a6e5605fc039050e