### PR TITLE
Add ROMM platform organizer and tests

### DIFF
--- a/src/rom_library_organizer/platforms/romm.py
+++ b/src/rom_library_organizer/platforms/romm.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from .base import PlatformOrganizer
+
+
+class ROMMPlatformOrganizer(PlatformOrganizer):
+    """Organize ROMs following ROMM's folder structure."""
+
+    SUPPORTED_EXTENSIONS = {
+        ".nes",
+        ".sfc",
+        ".smc",
+        ".gba",
+        ".gb",
+        ".gbc",
+        ".n64",
+        ".z64",
+        ".v64",
+        ".nds",
+        ".iso",
+        ".bin",
+    }
+
+    @classmethod
+    def is_supported(cls, file: Path) -> bool:
+        """Return ``True`` if ``file`` has a recognised ROM extension."""
+        return file.suffix.lower() in cls.SUPPORTED_EXTENSIONS
+
+    @staticmethod
+    def _sanitize(value: str) -> str:
+        """Return a filesystem-safe version of ``value``."""
+        value = re.sub(r"[<>:\"/\\|?*]", " ", value)
+        value = re.sub(r"\s+", " ", value)
+        return value.strip()
+
+    def rename(self, file_metadata: Mapping[str, Any]) -> str:
+        """Return destination path for ``file_metadata``.
+
+        The path follows ROMM's convention of
+        ``<platform>/<game>/<game><extension>``. ``game`` includes the region
+        in parentheses when provided.
+        """
+
+        platform = self._sanitize(str(file_metadata.get("platform", "Unknown Platform")))
+        name = self._sanitize(str(file_metadata.get("name", "Unknown Game")))
+        region = file_metadata.get("region")
+        extension = str(file_metadata.get("extension", ""))
+
+        base_name = f"{name} ({region})" if region else name
+        base_name = self._sanitize(base_name)
+
+        return f"{platform}/{base_name}/{base_name}{extension}"

--- a/tests/test_platform_romm.py
+++ b/tests/test_platform_romm.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from rom_library_organizer.platforms.romm import ROMMPlatformOrganizer
+
+
+def test_is_supported(tmp_path: Path) -> None:
+    organizer = ROMMPlatformOrganizer()
+    rom = tmp_path / "game.nes"
+    rom.write_bytes(b"rom")
+    assert organizer.is_supported(rom)
+    not_rom = tmp_path / "readme.txt"
+    not_rom.write_text("hi")
+    assert not organizer.is_supported(not_rom)
+
+
+def test_rename_and_place(tmp_path: Path) -> None:
+    organizer = ROMMPlatformOrganizer()
+    rom = tmp_path / "oot.z64"
+    rom.write_bytes(b"data")
+    metadata = {
+        "platform": "Nintendo 64",
+        "name": "Legend of Zelda: Ocarina of Time",
+        "region": "USA",
+        "extension": ".z64",
+    }
+    rel_path = organizer.rename(metadata)
+    dest = tmp_path / rel_path
+    dest.parent.mkdir(parents=True)
+    rom.rename(dest)
+
+    assert dest.exists()
+    assert dest.name == "Legend of Zelda Ocarina of Time (USA).z64"
+    assert dest.parent.name == "Legend of Zelda Ocarina of Time (USA)"
+    assert dest.parent.parent.name == "Nintendo 64"


### PR DESCRIPTION
## Summary
- add ROMMPlatformOrganizer implementing ROMM folder/filename conventions
- include unit tests for ROMM organizer rename logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4450fc6b88326828bb88facb5c4b6