### PR TITLE
Add NextUI platform organizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ This command currently displays a placeholder message.
 - Provide a command-line interface for organizing ROM files.
 - Support metadata scraping and library management.
 - Offer extensible plugin architecture for various console platforms.
+
+## NextUI Metadata
+
+When organizing ROMs for the hypothetical *NextUI* frontend, the
+``NextUIPlatformOrganizer`` expects a couple of extra metadata fields:
+
+- ``region`` – used to group games inside platform folders. When missing,
+  files fall back to ``Unknown Region``.
+- ``disc`` / ``disc_number`` – optional number appended to the filename as
+  ``- Disc X`` for multi-disc titles.
+
+The resulting structure follows ``<platform>/<region>/<game>[- Disc #]<ext>``.

--- a/src/rom_library_organizer/platforms/nextui.py
+++ b/src/rom_library_organizer/platforms/nextui.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from .base import PlatformOrganizer
+
+
+class NextUIPlatformOrganizer(PlatformOrganizer):
+    """Organize ROMs according to NextUI's folder structure.
+
+    NextUI groups games first by platform and then by region. The final
+    filename includes the disc number when provided. All components are
+    sanitised to ensure filesystem compatibility.
+    """
+
+    SUPPORTED_EXTENSIONS = {
+        ".nes",
+        ".sfc",
+        ".smc",
+        ".gba",
+        ".gb",
+        ".gbc",
+        ".n64",
+        ".z64",
+        ".v64",
+        ".nds",
+        ".iso",
+        ".bin",
+        ".cue",
+    }
+
+    @classmethod
+    def is_supported(cls, file: Path) -> bool:
+        """Return ``True`` if ``file`` has a recognised ROM extension."""
+
+        return file.suffix.lower() in cls.SUPPORTED_EXTENSIONS
+
+    @staticmethod
+    def _sanitize(value: str) -> str:
+        """Return a filesystem-safe version of ``value``."""
+
+        value = re.sub(r"[<>:\"/\\|?*]", " ", value)
+        value = re.sub(r"\s+", " ", value)
+        return value.strip()
+
+    def rename(self, file_metadata: Mapping[str, Any]) -> str:
+        """Return destination path for ``file_metadata``.
+
+        The path follows NextUI's convention of
+        ``<platform>/<region>/<game>[- Disc #]<extension>``. ``region`` is
+        required by NextUI to separate releases geographically. ``disc`` (or
+        ``disc_number``) is appended to the filename when present.
+        """
+
+        platform = self._sanitize(str(file_metadata.get("platform", "Unknown Platform")))
+        region = self._sanitize(str(file_metadata.get("region", "Unknown Region")))
+        name = self._sanitize(str(file_metadata.get("name", "Unknown Game")))
+        extension = str(file_metadata.get("extension", ""))
+        disc = file_metadata.get("disc") or file_metadata.get("disc_number")
+
+        base_name = name
+        if disc:
+            base_name += f" - Disc {disc}"
+        base_name = self._sanitize(base_name)
+
+        return f"{platform}/{region}/{base_name}{extension}"

--- a/tests/test_platform_nextui.py
+++ b/tests/test_platform_nextui.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from rom_library_organizer.platforms.nextui import NextUIPlatformOrganizer
+
+
+def test_is_supported(tmp_path: Path) -> None:
+    organizer = NextUIPlatformOrganizer()
+    rom = tmp_path / "game.nes"
+    rom.write_bytes(b"rom")
+    assert organizer.is_supported(rom)
+    not_rom = tmp_path / "readme.txt"
+    not_rom.write_text("hi")
+    assert not organizer.is_supported(not_rom)
+
+
+def test_rename(tmp_path: Path) -> None:
+    organizer = NextUIPlatformOrganizer()
+    rom = tmp_path / "ff7_disc2.bin"
+    rom.write_bytes(b"data")
+    metadata = {
+        "platform": "Sony Playstation",
+        "name": "Final Fantasy VII",
+        "region": "USA",
+        "disc": 2,
+        "extension": ".bin",
+    }
+    rel_path = organizer.rename(metadata)
+    dest = tmp_path / rel_path
+    dest.parent.mkdir(parents=True)
+    rom.rename(dest)
+
+    assert dest.exists()
+    assert dest.parent.name == "USA"
+    assert dest.parent.parent.name == "Sony Playstation"
+    assert dest.name == "Final Fantasy VII - Disc 2.bin"


### PR DESCRIPTION
## Summary
- add NextUI platform organiser to handle platform/region/disc folder structure
- document NextUI-specific metadata fields for region and disc
- test NextUI organizer behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5859bfa388326ba0103948d8e684f