### PR TITLE
docs: add usage examples and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Thank you for your interest in contributing to ROM Library Organizer! This document outlines the process and standards for contributing.
+
+## Coding Standards
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/) style guidelines.
+- Use type hints for new code and prefer explicit imports.
+- Keep functions small and focused; add docstrings for public methods and classes.
+
+## Testing
+
+- Install development dependencies: `pip install -e .`
+- Run the test suite with `pytest` and ensure all tests pass before submitting a pull request.
+- Add tests for any new features or bug fixes.
+
+## Adding Support for a New Platform
+
+1. Create a new module in `src/rom_library_organizer/platforms/` that subclasses `PlatformOrganizer`.
+2. Implement the required `is_supported` and `rename` methods.
+3. Add tests under `tests/` covering the new platform logic.
+4. Document the platform in the README and include a CLI example.
+
+## Submitting Changes
+
+- Fork the repository and create your feature branch from `main`.
+- Commit your changes with clear, descriptive messages.
+- Open a pull request and describe the motivation and approach.
+
+We appreciate your help in improving ROM Library Organizer!

--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ rom-library-organizer
 
 This command currently displays a placeholder message.
 
+## CLI Examples
+
+The tool accepts a directory of ROM files and one or more platform names. The
+examples below show how to invoke the organizer for each supported platform.
+
+### Batocera
+
+```bash
+rom-library-organizer /path/to/roms batocera
+```
+
+### Knulli
+
+```bash
+rom-library-organizer /path/to/roms knulli
+```
+
+### NextUI
+
+```bash
+rom-library-organizer /path/to/roms nextui
+```
+
+### ROMM
+
+```bash
+rom-library-organizer /path/to/roms romm
+```
+
 ## Goals
 
 - Provide a command-line interface for organizing ROM files.


### PR DESCRIPTION
## Summary
- document platform-specific CLI usage examples
- add contributing guide with coding and testing standards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c58c658c5c83269876cd43eb44e392